### PR TITLE
Add Node.js proxy server for Foundry actor lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+npm-debug.log*
+

--- a/ImpMal.html
+++ b/ImpMal.html
@@ -11,6 +11,14 @@
 </head>
 <body>
     <h1>Imperium Maledictum Character Creator</h1>
+    <div id="foundryActorWrapper">
+        <h2>Load Actor From Foundry</h2>
+        <p class="foundry-description">Provide an actor ID to request data from your FoundryVTT instance.</p>
+        <label for="actorIdInput">Actor ID</label>
+        <input id="actorIdInput" type="text" placeholder="e.g. AbCdEf123456">
+        <button id="fetchActorButton" type="button">Fetch Actor</button>
+        <pre id="actorResult" aria-live="polite"></pre>
+    </div>
     <div id="nameWrapper">
         <form id="nameForm">
             <label for="nameInput">Enter a name for your character:</label>
@@ -197,8 +205,9 @@
         </div><!-- #statSheet .sheet-panel -->
     </div><!-- #sheetWrapper -->
 
+    <script src="foundryApiClient.js?"></script>
     <script src="Character.js?"></script>
     <script src="main.js?"></script>
     <script src="eventListeners.js?"></script>
-</body>    
+</body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,36 @@
 Character Creator for Cubicle 7's Imperium Maledictum ttrpg
 
-notes: 
+## Node.js bootstrap for Foundry actor lookups
+
+The project now includes a tiny Node.js server that serves the static site and
+proxies actor lookups to a FoundryVTT REST API module. The proxy keeps your
+Foundry credentials out of the browser while offering a straightforward endpoint
+for the front-end.
+
+### Configuration
+
+Set the following environment variables before starting the server:
+
+* `FOUNDRY_API_BASE_URL` – Base URL for the REST module. Include the `/` at the
+  end if your module expects it (for example
+  `https://example.com/foundryvtt/api/`).
+* `FOUNDRY_API_KEY` – Optional bearer token that should be sent with requests
+  to Foundry. Leave unset if the module is exposed without authentication.
+
+### Run locally
+
+```bash
+npm start
+```
+
+The site will be available at `http://localhost:3000`. Use the "Load Actor From
+Foundry" panel to test an actor fetch. Errors from the Foundry instance are
+relayed back to the browser to aid debugging. Node.js 18+ (20+ recommended) is
+required so the built-in `fetch` API is available on the server.
+
+---
+
+notes:
 trying out kebab-case for classes. This'll alow me to query all sheet-* elements and so forth. ID's still camelCase
 
 Layout:

--- a/foundryApiClient.js
+++ b/foundryApiClient.js
@@ -1,0 +1,74 @@
+(function () {
+  const actorInput = document.getElementById('actorIdInput');
+  const actorButton = document.getElementById('fetchActorButton');
+  const actorResult = document.getElementById('actorResult');
+
+  if (!actorInput || !actorButton || !actorResult) {
+    return;
+  }
+
+  function setResult(message, state) {
+    actorResult.textContent = message;
+    actorResult.classList.remove('success', 'error');
+    if (state) {
+      actorResult.classList.add(state);
+    }
+  }
+
+  async function requestActor(actorId) {
+    const response = await fetch(`/api/actors/${encodeURIComponent(actorId)}`);
+    let payload = null;
+
+    try {
+      payload = await response.json();
+    } catch (error) {
+      payload = null;
+    }
+
+    if (!response.ok) {
+      const message = payload && payload.error ? payload.error : 'Unable to retrieve actor.';
+      const details = payload && payload.details ? payload.details : null;
+      let detailText = '';
+
+      if (details) {
+        if (typeof details === 'string') {
+          detailText = `\n${details}`;
+        } else {
+          detailText = `\n${JSON.stringify(details, null, 2)}`;
+        }
+      }
+
+      setResult(`${message}${detailText}`, 'error');
+      return;
+    }
+
+    const actorData = payload && payload.actor ? payload.actor : payload;
+    setResult(JSON.stringify(actorData, null, 2), 'success');
+  }
+
+  actorButton.addEventListener('click', async () => {
+    const actorId = actorInput.value.trim();
+
+    if (!actorId) {
+      setResult('Enter an actor ID to fetch.', 'error');
+      actorInput.focus();
+      return;
+    }
+
+    setResult('Fetching actor data...', null);
+
+    try {
+      await requestActor(actorId);
+    } catch (error) {
+      setResult(`Failed to contact server.\n${error.message}`, 'error');
+    }
+  });
+
+  actorInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      actorButton.click();
+    }
+  });
+})();
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "impmal_cc",
+  "version": "1.0.0",
+  "description": "Character Creator for Cubicle 7's Imperium Maledictum ttrpg",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,182 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 3000;
+const FOUNDRY_API_BASE_URL = process.env.FOUNDRY_API_BASE_URL;
+const FOUNDRY_API_KEY = process.env.FOUNDRY_API_KEY;
+const BASE_DIR = __dirname;
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+    'Cache-Control': 'no-store'
+  });
+  res.end(body);
+}
+
+function ensureTrailingSlash(value) {
+  if (!value) {
+    return value;
+  }
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+async function proxyActorRequest(res, requestUrl) {
+  const actorId = requestUrl.pathname.replace('/api/actors/', '').trim();
+
+  if (!actorId) {
+    sendJson(res, 400, { error: 'Actor ID is required.' });
+    return;
+  }
+
+  if (!FOUNDRY_API_BASE_URL) {
+    sendJson(res, 500, { error: 'Foundry API base URL is not configured.' });
+    return;
+  }
+
+  try {
+    const baseUrl = ensureTrailingSlash(FOUNDRY_API_BASE_URL);
+    const actorUrl = new URL(`actors/${encodeURIComponent(actorId)}`, baseUrl);
+    actorUrl.search = requestUrl.searchParams.toString();
+
+    const headers = {
+      Accept: 'application/json'
+    };
+
+    if (FOUNDRY_API_KEY) {
+      headers.Authorization = `Bearer ${FOUNDRY_API_KEY}`;
+    }
+
+    const response = await fetch(actorUrl, { headers });
+    const text = await response.text();
+
+    if (!response.ok) {
+      let details;
+      try {
+        details = JSON.parse(text);
+      } catch (error) {
+        details = text;
+      }
+
+      sendJson(res, response.status, {
+        error: 'Failed to fetch actor from Foundry API.',
+        details
+      });
+      return;
+    }
+
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch (error) {
+      sendJson(res, 502, {
+        error: 'Foundry API returned non-JSON response.',
+        details: text
+      });
+      return;
+    }
+
+    sendJson(res, 200, { actor: data });
+  } catch (error) {
+    sendJson(res, 500, {
+      error: 'Unexpected error retrieving actor data.',
+      details: error.message
+    });
+  }
+}
+
+function getContentType(filePath) {
+  switch (path.extname(filePath).toLowerCase()) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'application/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.ico':
+      return 'image/x-icon';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function resolveStaticPath(pathname) {
+  if (pathname === '/' || pathname === '') {
+    return path.join(BASE_DIR, 'ImpMal.html');
+  }
+
+  const stripped = pathname.replace(/^\/+/, '');
+  const resolved = path.resolve(BASE_DIR, stripped);
+
+  if (!resolved.startsWith(BASE_DIR)) {
+    return null;
+  }
+
+  return resolved;
+}
+
+function serveStaticFile(res, pathname) {
+  const filePath = resolveStaticPath(pathname);
+
+  if (!filePath) {
+    sendJson(res, 403, { error: 'Forbidden' });
+    return;
+  }
+
+  fs.stat(filePath, (statErr, stats) => {
+    if (statErr) {
+      if (statErr.code === 'ENOENT') {
+        sendJson(res, 404, { error: 'Not Found' });
+        return;
+      }
+      sendJson(res, 500, { error: 'Failed to access requested file.' });
+      return;
+    }
+
+    if (stats.isDirectory()) {
+      sendJson(res, 403, { error: 'Directory access is forbidden.' });
+      return;
+    }
+
+    fs.readFile(filePath, (readErr, data) => {
+      if (readErr) {
+        sendJson(res, 500, { error: 'Failed to read requested file.' });
+        return;
+      }
+
+      res.writeHead(200, {
+        'Content-Type': getContentType(filePath),
+        'Content-Length': data.length
+      });
+      res.end(data);
+    });
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const requestUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+
+  if (req.method === 'GET' && requestUrl.pathname.startsWith('/api/actors/')) {
+    proxyActorRequest(res, requestUrl);
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    sendJson(res, 405, { error: 'Method Not Allowed' });
+    return;
+  }
+
+  serveStaticFile(res, requestUrl.pathname);
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -112,6 +112,78 @@ h1 {
     text-align: center;
 }
 
+#foundryActorWrapper {
+    width: min(720px, 100%);
+    margin: 0 auto 28px;
+    padding: 22px 26px;
+    display: grid;
+    gap: 12px;
+    background: rgba(6, 25, 16, 0.82);
+    border: 1px solid var(--cogitator-green-dim);
+    border-radius: 8px;
+    box-shadow: var(--panel-glow);
+}
+
+#foundryActorWrapper h2 {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--cogitator-green-bright);
+}
+
+.foundry-description {
+    margin: 0;
+    color: var(--cogitator-green-muted);
+}
+
+#foundryActorWrapper label {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--cogitator-green);
+}
+
+#fetchActorButton {
+    justify-self: start;
+    padding: 12px 28px;
+    border-radius: 8px;
+    border: 1px solid var(--cogitator-green-dim);
+    background: linear-gradient(180deg, rgba(34, 126, 79, 0.95) 0%, rgba(18, 74, 44, 0.95) 100%);
+    color: var(--cogitator-green-bright);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    cursor: pointer;
+    box-shadow: 0 0 16px rgba(124, 255, 182, 0.45);
+    transition: transform 120ms ease, filter 160ms ease, box-shadow 160ms ease;
+}
+
+#fetchActorButton:hover,
+#fetchActorButton:focus-visible {
+    filter: brightness(1.1);
+    transform: translateY(-1px);
+    box-shadow: 0 0 20px rgba(155, 247, 184, 0.6);
+}
+
+#actorResult {
+    min-height: 140px;
+    padding: 14px 16px;
+    background: rgba(9, 40, 24, 0.7);
+    border: 1px solid rgba(155, 247, 184, 0.25);
+    border-radius: 6px;
+    font-size: 1rem;
+    line-height: 1.3;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+}
+
+#actorResult.success {
+    color: var(--cogitator-green-bright);
+}
+
+#actorResult.error {
+    color: var(--cogitator-error);
+}
+
 #nameForm {
     display: grid;
     gap: 12px;


### PR DESCRIPTION
## Summary
- add a minimal Node.js HTTP server that serves the static assets and proxies actor requests to the Foundry REST API
- add a Foundry actor lookup panel on the page with a bare-bones client script and themed styling
- document the Node-based workflow, include project metadata, and ignore common local artifacts

## Testing
- PORT=4000 npm start
- curl -s http://localhost:4000/ | head -n 5
- curl -s -w '\n%{http_code}\n' http://localhost:4000/api/actors/test


------
https://chatgpt.com/codex/tasks/task_e_68d42769c24883289df6704bed893a99